### PR TITLE
ES-890021 - Null reference exception occurs while pressing the backbutton in UWP demos.

### DIFF
--- a/SfSpreadsheet/Showcase/Spreadsheet.xaml.cs
+++ b/SfSpreadsheet/Showcase/Spreadsheet.xaml.cs
@@ -63,7 +63,6 @@ namespace SpreadsheetSamples
         public void Dispose()
         {
             this.Unloaded -= SpreadsheetShowcase_Unloaded;
-            //ES-890021 - Here we have called the ribbon.Dispose() method first before the this.Spreadsheet.Dispose to fix the null reference exception occurs while pressing the backbutton in UWP demos.
             this.ribbon.Dispose();
             this.spreadsheet.Dispose(); 
             Resources.Clear();

--- a/SfSpreadsheet/Showcase/Spreadsheet.xaml.cs
+++ b/SfSpreadsheet/Showcase/Spreadsheet.xaml.cs
@@ -63,8 +63,9 @@ namespace SpreadsheetSamples
         public void Dispose()
         {
             this.Unloaded -= SpreadsheetShowcase_Unloaded;
-            this.spreadsheet.Dispose();
+            //ES-890021 - Here we have called the ribbon.Dispose() method first before the this.Spreadsheet.Dispose to fix the null reference exception occurs while pressing the backbutton in UWP demos.
             this.ribbon.Dispose();
+            this.spreadsheet.Dispose(); 
             Resources.Clear();
             GC.Collect();
             GC.WaitForPendingFinalizers();


### PR DESCRIPTION
Hi @AmalRajUmapathySelvam ,

The issue arises because the spreadsheet is disposed of first, which leads to a null style when we attempt to save the font and update the ribbon based on the spreadsheet's current cell style. To resolve this issue, we should dispose of the ribbon first. Could you please review this?

### Bug
[Task 890021](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/890021): Encounter an Null reference exception occurs while pressing the backbutton in Spreadsheet UWP demos.
 
### Bug Description
Null reference exception occurs while pressing the backbutton in Spreadsheet UWP demos. 

### Root Cause
The cause of the issue is that during the dispose process, we first try to dispose of the spreadsheet and then move on to dispose of the ribbon. While disposing of the ribbon, we try to handle the CurrentCellStyle of SfSpreadsheet. In this case, we encounter a NullReferenceException because SfSpreadsheet becomes null. This happens because we initially try to dispose of the SfSpreadsheet object and then try to remove the ribbon objects.
 
### Fix Details
 
To resolve this issue, we should dispose of the ribbon first and then dispose of the spreadsheet.
 
 
### Screen Shots
**Before**
 
![image](https://github.com/syncfusion/uwp-demos/assets/89458634/ca566a7f-60f7-43a9-b4dd-70d798388dd7)


 **After**
 

https://github.com/syncfusion/uwp-demos/assets/89458634/1a1d7471-152a-4065-8f72-f5251c71c9f5


